### PR TITLE
Switch to uint32 for veccounts

### DIFF
--- a/hist_2d.c
+++ b/hist_2d.c
@@ -165,7 +165,7 @@ hist_2d_finalfn(PG_FUNCTION_ARGS)
   if (state == NULL) PG_RETURN_NULL();
 
   for (i = 0; i < state->state.nelems; i++) {
-    state->state.dvalues[i] = Int32GetDatum((int32)state->veccounts[i]);
+    state->state.dvalues[i] = UInt32GetDatum(state->veccounts[i]);
   }
 
   dims[0] = state->vecvalues[0].i32;

--- a/hist_md.c
+++ b/hist_md.c
@@ -234,7 +234,7 @@ hist_md_finalfn(PG_FUNCTION_ARGS)
   if (state == NULL) PG_RETURN_NULL();
 
   for (i = 0; i < state->state.nelems; i++) {
-    state->state.dvalues[i] = Int32GetDatum((int32)state->veccounts[i]);
+    state->state.dvalues[i] = UInt32GetDatum(state->veccounts[i]);
   }
 
   dims = MemoryContextAlloc(aggContext, HIST_MD_DIMENSIONS(state) * sizeof(int));

--- a/util.c
+++ b/util.c
@@ -27,7 +27,7 @@ typedef struct VecArrayBuildState {
   ArrayBuildState state;
   Oid inputElementType;
   pgnum *vecvalues;     // The current aggregate result for each position.
-  int *veccounts;       // How many values in this position are not null.
+  uint32 *veccounts;     // How many values in this position are not null.
   pgnum *vectmpvalues;  // Intermediate results if we need them.
 } VecArrayBuildState;
 
@@ -56,9 +56,9 @@ initVecArrayResultWithNulls(Oid input_element_type, Oid state_element_type, Memo
   astate->inputElementType = input_element_type;
   astate->vecvalues = (pgnum *)
     MemoryContextAlloc(rcontext, astate->state.alen * sizeof(pgnum));
-  astate->veccounts = (int *)
-    MemoryContextAlloc(rcontext, astate->state.alen * sizeof(int));
-  memset(astate->veccounts, 0, astate->state.alen * sizeof(int));
+  astate->veccounts = (uint32 *)
+    MemoryContextAlloc(rcontext, astate->state.alen * sizeof(uint32));
+  memset(astate->veccounts, 0, astate->state.alen * sizeof(uint32));
   astate->vectmpvalues = (pgnum *)
     MemoryContextAlloc(rcontext, astate->state.alen * sizeof(pgnum));
   


### PR DESCRIPTION
This is in response to #3, to switch from int to uint32 for the veccounts field and allow processing more input rows in the functions that keep track of counts.